### PR TITLE
Front 20 components icon

### DIFF
--- a/src/client/components/icon/Icon.tsx
+++ b/src/client/components/icon/Icon.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+import { OwnProps } from './types';
+import './icon.scss';
+
+const Icon: FC<OwnProps> = (props: OwnProps) => {
+  const {
+    name,
+    size,
+    ...otherProps
+  } = props;
+  const iconSize = props.size ? `icon_size-${props.size}` : '';
+  const className = `icon material-icons ${iconSize} ${props.className ? props.className : ''}`;
+  return (
+    <span {...otherProps} className={className}>{name}</span>
+  );
+};
+
+export default Icon;

--- a/src/client/components/icon/icon.scss
+++ b/src/client/components/icon/icon.scss
@@ -1,0 +1,11 @@
+.material-icons {
+  &.icon {
+    &_size {
+      @for $i from 1 through 4 {
+        &-#{$i} {
+          font-size: #{1.2 * $i}rem;
+        }
+      }
+    }
+  }
+}

--- a/src/client/components/icon/index.ts
+++ b/src/client/components/icon/index.ts
@@ -1,0 +1,6 @@
+import { memo } from 'react';
+
+import Icon from './Icon';
+import { OwnProps } from './types';
+
+export default memo<OwnProps>(Icon);

--- a/src/client/components/icon/types.ts
+++ b/src/client/components/icon/types.ts
@@ -1,0 +1,6 @@
+import { HTMLAttributes } from 'react';
+
+export type OwnProps = {
+  name: string;
+  size?: number;
+} & HTMLAttributes<HTMLDivElement>;

--- a/src/client/css/typo.scss
+++ b/src/client/css/typo.scss
@@ -1,6 +1,7 @@
 @import "var";
 @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Balsamiq+Sans:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 
 html {
   font-family: 'Balsamiq Sans', cursive;


### PR DESCRIPTION
Размеры поддерживаются от 1 до 4 (шаг в `12px` или `1.2rem`), указываются через опциональный проп `size={4}`. Взяты из [документации](https://google.github.io/material-design-icons/#styling-icons-in-material-design).